### PR TITLE
Fix 2nd code review issues

### DIFF
--- a/scripts/echo360.js
+++ b/scripts/echo360.js
@@ -109,7 +109,7 @@
           }
         }
         else if (message.event === 'timeline') {
-          duration = message.data.duration;
+          duration = message.data.duration ?? this.getDuration();
           currentTime = message.data.currentTime ?? 0;
           if (message.data.playing) {
             this.trigger('stateChange', H5P.Video.PLAYING);

--- a/scripts/echo360.js
+++ b/scripts/echo360.js
@@ -1,5 +1,6 @@
 /** @namespace Echo */
-H5P.VideoEchoVideo = (function () {
+
+  let numInstances = 0;
 
   /**
    * EchoVideo video player for H5P.
@@ -11,7 +12,6 @@ H5P.VideoEchoVideo = (function () {
    */
   function EchoPlayer(sources, options, l10n) {
     // State variables for the Player.
-    var numInstances = 0;
     let player = undefined;
     let buffered = 0;
     let currentQuality;

--- a/scripts/echo360.js
+++ b/scripts/echo360.js
@@ -78,7 +78,11 @@ H5P.VideoEchoVideo = (() => {
           this.trigger('loaded');
           this.loadingComplete = true;
           this.trigger('resize');
-          if (options.autoplay && document.featurePolicy.allowsFeature('autoplay')) {
+
+          if (
+            options.autoplay &&
+            document.featurePolicy?.allowsFeature('autoplay')
+          ) {
             this.play();
             this.trigger('stateChange', H5P.Video.PLAYING);
           }

--- a/scripts/echo360.js
+++ b/scripts/echo360.js
@@ -166,7 +166,8 @@
         // Implicit conversion to millis
         queryString += 'startTimeMillis=' + options.startAt + '000&';
       }
-      wrapperElement.innerHTML = '<iframe src="' + sources[0].path + '" style="display: inline-block; width: 100%; height: 100%;" allow="autoplay; fullscreen" frameborder="0"></iframe>';
+
+      wrapperElement.innerHTML = `<iframe src="${sources[0].path}${queryString}" style="display: inline-block; width: 100%; height: 100%;" allow="autoplay; fullscreen" frameborder="0"></iframe>`;
       player = wrapperElement.firstChild;
       // Create a new player
       registerEchoPlayerEventListeneners(player);

--- a/scripts/echo360.js
+++ b/scripts/echo360.js
@@ -169,7 +169,7 @@ H5P.VideoEchoVideo = (() => {
       }
       if (options.startAt) {
         // Implicit conversion to millis
-        queryString += 'startTimeMillis=' + options.startAt + '000&';
+        queryString += `startTimeMillis=${options.startAt * 1000}&`;
       }
 
       wrapperElement.innerHTML = `<iframe src="${sources[0].path}${queryString}" style="display: inline-block; width: 100%; height: 100%;" allow="autoplay; fullscreen" frameborder="0"></iframe>`;

--- a/scripts/echo360.js
+++ b/scripts/echo360.js
@@ -1,4 +1,5 @@
 /** @namespace Echo */
+H5P.VideoEchoVideo = (() => {
 
   let numInstances = 0;
 
@@ -54,8 +55,8 @@
      */
     const mapQualityLevels = (qualityLevels) => {
       const qualities = qualityLevels.map((quality) => {
-        return { label: quality.label.toLowerCase(), name: quality.value }
-      })
+        return { label: quality.label.toLowerCase(), name: quality.value };
+      });
       return qualities;
     };
 

--- a/scripts/echo360.js
+++ b/scripts/echo360.js
@@ -80,9 +80,8 @@
           if (options.autoplay && document.featurePolicy.allowsFeature('autoplay')) {
             this.play();
             this.trigger('stateChange', H5P.Video.PLAYING);
-          } else {
-            this.trigger('stateChange', H5P.Video.PAUSED);
           }
+
           return true;
         });
       };
@@ -107,9 +106,6 @@
           this.trigger('resize');
           if (message.data.playing) {
             this.trigger('stateChange', H5P.Video.PLAYING);
-          }
-          else {
-            this.trigger('stateChange', H5P.Video.PAUSED);
           }
         }
         else if (message.event === 'timeline') {


### PR DESCRIPTION
When merged in, will address a couple of issues:
- Fix `numInstances` being an instance property. The variable is supposed to count the number of handlers that are used in the H5P context (there can be more than one) and to use the count to build a unique DOM element id. Therefore, turned into a class property.
- Stop triggering `paused` before the video had actually been played (thus having triggering a `played` event before). Other components down the line (like Interactive Video) do not expect that behavior.
- Fix updating `duration`. When the message event is `timeline`, then `message.data.duration` is `undefined`. Therefore, looping would not work. Also, since `duration` is used in `getDuration()`, the return value would be `undefined` and thus wrong. Using `getDuration` as fallback value. Should only cause trouble if you ever intend to remove all videos completely, so duration might need to be `undefined` again - doubt that though.
- Use query string for passing content type parameters. The query string to be passed to your player was properly built, but not passed with the iframe source parameter. Also using a template string literal now.
- Make eslint happy.
- Make robust for `document.featurePolicy`. That feature is experimental (not available in Firefox/Safari) and could lead to a crash.
- Fix startAt handling. The value that is passed is a float containing seconds, concatenating 3 zeros doesn't work.